### PR TITLE
Fixed images to fill available space

### DIFF
--- a/XYZReader/src/main/res/layout/fragment_article_detail.xml
+++ b/XYZReader/src/main/res/layout/fragment_article_detail.xml
@@ -21,8 +21,9 @@
                 <!--suppress AndroidLintContentDescription -->
                 <ImageView
                     android:id="@+id/photo"
-                    android:layout_width="100dp"
-                    android:layout_height="100dp" />
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:scaleType="centerCrop"/>
 
                 <View
                     android:layout_width="match_parent"

--- a/XYZReader/src/main/res/layout/list_item_article.xml
+++ b/XYZReader/src/main/res/layout/list_item_article.xml
@@ -18,9 +18,10 @@
         <!--suppress AndroidLintContentDescription -->
         <com.example.xyzreader.ui.DynamicHeightNetworkImageView
             android:id="@+id/thumbnail"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:background="@color/photo_placeholder" />
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/photo_placeholder"
+            android:scaleType="centerCrop"/>
 
         <TextView
             android:id="@+id/article_title"


### PR DESCRIPTION
Updated the provided article images to use `centerCrop` scale type and updated the element's width & height values to accommodate this.